### PR TITLE
Revise order of subsections in §4

### DIFF
--- a/drafts/latest/index.html
+++ b/drafts/latest/index.html
@@ -1220,7 +1220,11 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-document">
 
-<h3>+Document</h3>
+<h3>Document</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-document.html"></div>
 
@@ -1256,7 +1260,11 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-kind">
 
-<h3>+Kind</h3>
+<h3>Kind</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-kind.html"></div>
 
@@ -1311,7 +1319,11 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-provenance-statement">
 
-<h3>+Provenance Statement</h3>
+<h3>Provenance Statement</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-provenance-statement.html"></div>
 
@@ -1346,7 +1358,11 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-media-type">
 
-<h3>+Media Type</h3>
+<h3>Media Type</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-media-type.html"></div>
 
@@ -1381,7 +1397,11 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-rights-statement">
 
-<h3>+Rights Statement</h3>
+<h3>Rights Statement</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-rights-statement.html"></div>
 
@@ -1416,7 +1436,11 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-standard">
 
-<h3>+Standard</h3>
+<h3>Standard</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-standard.html"></div>
 

--- a/drafts/latest/index.html
+++ b/drafts/latest/index.html
@@ -101,8 +101,8 @@ The views expressed are purely those of the author and may not in any circumstan
 -->
 
 <p>This document contains version 2.0.0 of the specification for GeoDCAT-AP, an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [[DCAT-AP]] for describing geospatial datasets, dataset series, and services.</p>
-<p>Its basic use case is to make spatial datasets, dataset series, and services searchable on general data portals, thereby making geospatial information better findable across borders and sectors. For this purpose, GeoDCAT-AP provides an RDF vocabulary and the corresponding RDF syntax binding for the union of metadata elements of the core profile of ISO 19115:2003 [[ISO-19115]] and those defined in the framework of the INSPIRE Directive [[INSPIRE-DIR]].</p>
-<p><strong>The GeoDCAT-AP specification does not replace the INSPIRE Metadata Regulation</strong> [[?INSPIRE-MD-REG]] <strong>nor the INSPIRE Metadata technical guidelines</strong> [[INSPIRE-MD]] <strong>based on ISO 19115 and ISO 19119.</strong> Its purpose is to give owners of geospatial metadata the possibility to achieve more by providing the means of an <em>additional</em> implementation through harmonised RDF syntax bindings. Conversion rules to RDF syntax would allow Member States to maintain their collections of INSPIRE-relevant datasets following the INSPIRE Metadata technical guidelines based on [[ISO-19115]] and [[ISO-19119]], while at the same time publishing these collections on [[DCAT-AP]]-conformant data portals. A conversion to an RDF representation allows additional metadata elements to be displayed on general-purposed data portals, provided that such data portals are capable of displaying additional metadata elements. Additionally, data portals may be capable of providing machine-to-machine interfaces where additional metadata could be provided.</p>
+<p>Its basic use case is to make spatial datasets, dataset series, and services searchable on general data portals, thereby making geospatial information better findable across borders and sectors. For this purpose, GeoDCAT-AP provides an RDF vocabulary and the corresponding RDF syntax binding for the union of metadata elements of the core profile of ISO 19115:2003 [[ISO-19115]] and those defined in the framework of the INSPIRE Directive [[INSPIRE-DIR]].</p>
+<p><strong>The GeoDCAT-AP specification does not replace the INSPIRE Metadata Regulation</strong> [[?INSPIRE-MD-REG]] <strong>nor the INSPIRE Metadata technical guidelines</strong> [[INSPIRE-MD]] <strong>based on ISO 19115 and ISO 19119.</strong> Its purpose is to give owners of geospatial metadata the possibility to achieve more by providing the means of an <em>additional</em> implementation through harmonised RDF syntax bindings. Conversion rules to RDF syntax would allow Member States to maintain their collections of INSPIRE-relevant datasets following the INSPIRE Metadata technical guidelines based on [[ISO-19115]] and [[ISO-19119]], while at the same time publishing these collections on [[DCAT-AP]]-conformant data portals. A conversion to an RDF representation allows additional metadata elements to be displayed on general-purposed data portals, provided that such data portals are capable of displaying additional metadata elements. Additionally, data portals may be capable of providing machine-to-machine interfaces where additional metadata could be provided.</p>
 
 <section id="context">
 
@@ -342,14 +342,14 @@ The views expressed are purely those of the author and may not in any circumstan
 <section id="properties">
 
 <h2>Application Profile Properties per Class</h2>
-
+<!--
 <aside class="ednote">
 <p>To be revised.</p>
 <p>Classes have been listed as in [[DCAT-AP-20200608]], followed by those classes added by GeoDCAT-AP, so to preserve the section numbering.</p>
 <p>The current listing is not optimal, as the criteria behind the order in which classes are listed is unclear. Moreover, in each section there is no indication of whether a class is mandatory, recommended, or optional, and so readers need to go back to <a class="no-sectionRef" href="#classes"></a> to check this.</p>
 <p>An option would be to group classes into specific sections - mandatory classes, recommended classes, optional classes - and to list them in alphabetical order, as done in <a class="no-sectionRef" href="#classes"></a>.</p>
 </aside>
-
+-->
 <p>A quick reference table of properties per class is included in <a class="no-sectionRef" href="#quick-reference-of-classes-and-properties"></a>. The list of included properties contains all the properties in [[DCAT-AP-20200608]], plus a selection of properties from [[VOCAB-DCAT-2]] and [[DCTERMS]], on which GeoDCAT-AP expresses additional constraints or on which GeoDCAT-AP wants to emphasise their usage.
 <!--
 A property which is not mentioned but would be applicable for a class according to [[VOCAB-DCAT-2]] is considered out of scope for GeoDCAT-AP.
@@ -357,6 +357,61 @@ A property which is not mentioned but would be applicable for a class according 
 </p>
 
 <p>Examples on the use of these properties, encoded in [[Turtle]], are included in the relevant sections. The examples are also available in [[Turtle]] and RDF/XML [[RDF-SYNTAX-GRAMMAR]] from a <a href="./examples/">separate folder</a>.</p>
+
+<!-- Agent -->
+
+<section id="properties-for-agent">
+
+<h3>Agent</h3>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-agent.html"></div>
+
+<section id="mandatory-properties-for-agent">
+
+<h4>Mandatory property for Agent</h4>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-agent.html"></div>
+
+</section>
+
+<section id="recommended-properties-for-agent">
+
+<h4>Recommended property for Agent</h4>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-agent.html"></div>
+
+</section>
+
+<section id="optional-properties-for-agent">
+
+<h4>Optional properties for Agent</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#agent-address">address</a></li>
+<li>+<a href="#agent-affiliation">affiliation</a></li>
+<li>+<a href="#agent-email">email</a></li>
+<li>+<a href="#agent-phone">phone</a></li>
+<li>+<a href="#agent-url">URL</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-agent.html"></div>
+
+</section>
+
+<section id="examples-for-agent">
+
+<h4>Examples for Agent</h4>
+
+<aside class="example" id="ex-agent" title="Agent">
+<pre data-include-format="text" data-include="./examples/agent.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
 
 <!-- Catalogue -->
 
@@ -481,6 +536,113 @@ A property which is not mentioned but would be applicable for a class according 
 <aside class="example" id="ex-catalogue-record" title="Catalogue Record">
 <pre data-include-format="text" data-include="./examples/catalogue-record.ttl"></pre>
 </aside>
+
+</section>
+
+</section>
+
+<!-- Category -->
+
+<section id="properties-for-category">
+
+<h3>Category</h3>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-category.html"></div>
+
+<section id="mandatory-properties-for-category">
+
+<h4>Mandatory property for Category</h4>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-category.html"></div>
+
+</section>
+
+<section id="optional-properties-for-category">
+
+<h4>Optional property for Category</h4>
+
+<aside class="note">
+<p>The following property is not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#category-category-scheme">category scheme</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-category.html"></div>
+
+</section>
+
+<section id="examples-for-category">
+
+<h4>Examples for Category</h4>
+
+<aside class="example" id="ex-category" title="Category">
+<pre data-include-format="text" data-include="./examples/category.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
+<!-- Category Scheme -->
+
+<section id="properties-for-category-scheme">
+
+<h3>Category Scheme</h3>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-category-scheme.html"></div>
+
+<section id="mandatory-properties-for-category-scheme">
+
+<h4>Mandatory property for Category Scheme</h4>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-category-scheme.html"></div>
+
+</section>
+
+<section id="optional-properties-for-category-scheme">
+
+<h4>Optional properties for Category Scheme</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#category-scheme-creation-date">creation date</a></li>
+<li>+<a href="#category-scheme-release-date">release date</a></li>
+<li>+<a href="#category-scheme-modification-date">update / modification date</a></li>
+<li>+<a href="#category-scheme-version">version</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-category-scheme.html"></div>
+
+</section>
+
+<section id="examples-for-category-scheme">
+
+<h4>Examples for Category Scheme</h4>
+
+<aside class="example" id="ex-category-scheme" title="Category Scheme">
+<pre data-include-format="text" data-include="./examples/category-scheme.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
+<!-- Checksum -->
+
+<section id="properties-for-checksum">
+
+<h3>Checksum</h3>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-checksum.html"></div>
+
+<section id="mandatory-properties-for-checksum">
+
+<h4>Mandatory properties for Checksum</h4>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-checksum.html"></div>
 
 </section>
 
@@ -692,168 +854,6 @@ A property which is not mentioned but would be applicable for a class according 
 
 </section>
 
-<!-- Agent -->
-
-<section id="properties-for-agent">
-
-<h3>Agent</h3>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-agent.html"></div>
-
-<section id="mandatory-properties-for-agent">
-
-<h4>Mandatory property for Agent</h4>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-agent.html"></div>
-
-</section>
-
-<section id="recommended-properties-for-agent">
-
-<h4>Recommended property for Agent</h4>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-agent.html"></div>
-
-</section>
-
-<section id="optional-properties-for-agent">
-
-<h4>Optional properties for Agent</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#agent-address">address</a></li>
-<li>+<a href="#agent-affiliation">affiliation</a></li>
-<li>+<a href="#agent-email">email</a></li>
-<li>+<a href="#agent-phone">phone</a></li>
-<li>+<a href="#agent-url">URL</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-agent.html"></div>
-
-</section>
-
-<section id="examples-for-agent">
-
-<h4>Examples for Agent</h4>
-
-<aside class="example" id="ex-agent" title="Agent">
-<pre data-include-format="text" data-include="./examples/agent.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Category Scheme -->
-
-<section id="properties-for-category-scheme">
-
-<h3>Category Scheme</h3>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-category-scheme.html"></div>
-
-<section id="mandatory-properties-for-category-scheme">
-
-<h4>Mandatory property for Category Scheme</h4>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-category-scheme.html"></div>
-
-</section>
-
-<section id="optional-properties-for-category-scheme">
-
-<h4>Optional properties for Category Scheme</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#category-scheme-creation-date">creation date</a></li>
-<li>+<a href="#category-scheme-release-date">release date</a></li>
-<li>+<a href="#category-scheme-modification-date">update / modification date</a></li>
-<li>+<a href="#category-scheme-version">version</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-category-scheme.html"></div>
-
-</section>
-
-<section id="examples-for-category-scheme">
-
-<h4>Examples for Category Scheme</h4>
-
-<aside class="example" id="ex-category-scheme" title="Category Scheme">
-<pre data-include-format="text" data-include="./examples/category-scheme.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Category -->
-
-<section id="properties-for-category">
-
-<h3>Category</h3>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-category.html"></div>
-
-<section id="mandatory-properties-for-category">
-
-<h4>Mandatory property for Category</h4>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-category.html"></div>
-
-</section>
-
-<section id="optional-properties-for-category">
-
-<h4>Optional property for Category</h4>
-
-<aside class="note">
-<p>The following property is not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#category-category-scheme">category scheme</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-category.html"></div>
-
-</section>
-
-<section id="examples-for-category">
-
-<h4>Examples for Category</h4>
-
-<aside class="example" id="ex-category" title="Category">
-<pre data-include-format="text" data-include="./examples/category.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Checksum -->
-
-<section id="properties-for-checksum">
-
-<h3>Checksum</h3>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-checksum.html"></div>
-
-<section id="mandatory-properties-for-checksum">
-
-<h4>Mandatory properties for Checksum</h4>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-checksum.html"></div>
-
-</section>
-
-</section>
-
 <!-- Identifier -->
 
 <section id="properties-for-identifier">
@@ -1038,7 +1038,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-activity">
 
-<h3>Activity</h3>
+<h3>+Activity</h3>
 
 <aside class="note">
 <p>This class is not included in [[DCAT-AP-20200608]].</p>
@@ -1082,7 +1082,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-address-agent">
 
-<h3>Address (Agent)</h3>
+<h3>+Address (Agent)</h3>
 
 <aside class="note">
 <p>This class is not included in [[DCAT-AP-20200608]].</p>
@@ -1126,7 +1126,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-address-kind">
 
-<h3>Address (Kind)</h3>
+<h3>+Address (Kind)</h3>
 
 <aside class="note">
 <p>This class is not included in [[DCAT-AP-20200608]].</p>
@@ -1170,7 +1170,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-attribution">
 
-<h3>Attribution</h3>
+<h3>+Attribution</h3>
 
 <aside class="note">
 <p>This class is not included in [[DCAT-AP-20200608]].</p>
@@ -1220,7 +1220,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-document">
 
-<h3>Document</h3>
+<h3>+Document</h3>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-document.html"></div>
 
@@ -1256,7 +1256,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-kind">
 
-<h3>Kind</h3>
+<h3>+Kind</h3>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-kind.html"></div>
 
@@ -1311,7 +1311,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-provenance-statement">
 
-<h3>Provenance Statement</h3>
+<h3>+Provenance Statement</h3>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-provenance-statement.html"></div>
 
@@ -1346,7 +1346,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-media-type">
 
-<h3>Media Type</h3>
+<h3>+Media Type</h3>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-media-type.html"></div>
 
@@ -1381,7 +1381,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-rights-statement">
 
-<h3>Rights Statement</h3>
+<h3>+Rights Statement</h3>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-rights-statement.html"></div>
 
@@ -1416,7 +1416,7 @@ A property which is not mentioned but would be applicable for a class according 
 
 <section id="properties-for-standard">
 
-<h3>Standard</h3>
+<h3>+Standard</h3>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/class-standard.html"></div>
 
@@ -1695,7 +1695,7 @@ A property which is not mentioned but would be applicable for a class according 
 <li>The string is an appellation of a ‘named entity’. Examples are names of organisations or persons. These names may have parallel versions in other languages but those versions don’t need to be literal translations.</li>
 </ul>
 <p>Wherever values of properties are expressed with either type of string, the property can be repeated with translations in the case of free text and with parallel versions in case of named entities. For free text, e.g. in the cases of titles, descriptions and keywords, the <strong>language tag</strong> is mandatory. </p>
-<p>Language tags to be used with <code>rdfs:Literal</code> are defined by [[BCP47]], which allows the use of the "t" extension for text transformations defined in [[RFC6497]] with the field "t0" [[CLDR]] indicating a machine translation.</p>
+<p>Language tags to be used with <code>rdfs:Literal</code> are defined by [[BCP47]], which allows the use of the "t" extension for text transformations defined in [[RFC6497]] with the field "t0" [[CLDR]] indicating a machine translation.</p>
 <p>A language tag will look like: "en-t-es-t0-abcd", which conveys the information that the string is in English, translated from Spanish by machine translation using a tool named "abcd".</p>
 <p>For named entities, the language tag is optional and should only be provided if the parallel version of the name is strictly associated with a particular language. For example, the name ‘European Union’ has parallel versions in all official languages of the union, while a name like ‘W3C’ is not associated with a particular language and has no parallel versions.</p>
 <p>For linking to different language versions of associated web pages (e.g. landing pages) or documentation, a content negotiation [[CONNEG]] mechanism may be used whereby different content is served based on the Accept-Languages indicated by the browser. Using such a mechanism, the link to the page or document can resolve to different language versions of the page or document.</p>

--- a/drafts/latest/index.html
+++ b/drafts/latest/index.html
@@ -358,6 +358,138 @@ A property which is not mentioned but would be applicable for a class according 
 
 <p>Examples on the use of these properties, encoded in [[Turtle]], are included in the relevant sections. The examples are also available in [[Turtle]] and RDF/XML [[RDF-SYNTAX-GRAMMAR]] from a <a href="./examples/">separate folder</a>.</p>
 
+<!-- Activity -->
+
+<section id="properties-for-activity">
+
+<h3>+Activity</h3>
+
+<aside class="note">
+<p>This class is not included in [[DCAT-AP-20200608]].</p>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-activity.html"></div>
+
+<p>The use of this class in GeoDCAT-AP is illustrated in <a class="no-sectionRef" href="#conformance-test-results"></a>.</p>
+
+<section id="mandatory-properties-for-activity">
+
+<h4>Mandatory properties for Activity</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#activity-generated">generated</a></li>
+<li>+<a href="#activity-qualified-association">qualified association</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-activity.html"></div>
+
+</section>
+
+<section id="examples-for-activity">
+
+<h4>Examples for Activity</h4>
+
+<p><a href="#ex-activity"></a> shows the use of class <code>prov:Activity</code> to specify the results of a testing activity assessing the conformance of a given resource against a given specification - as illustrated in <a class="no-sectionRef" href="#conformance-test-results"></a>.</p>
+
+<aside class="example" id="ex-activity" title="A testing activity">
+<pre data-include-format="text" data-include="./examples/activity.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
+<!-- Address (Agent)-->
+
+<section id="properties-for-address-agent">
+
+<h3>+Address (Agent)</h3>
+
+<aside class="note">
+<p>This class is not included in [[DCAT-AP-20200608]].</p>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-address-agent.html"></div>
+
+<section id="recommended-properties-for-address-agent">
+
+<h4>Recommended properties for Address (Agent)</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#address-agent-administrative-area">administrative area</a></li>
+<li>+<a href="#address-agent-city">city</a></li>
+<li>+<a href="#address-agent-country">country</a></li>
+<li>+<a href="#address-agent-postal-code">postal code</a></li>
+<li>+<a href="#address-agent-street-address">street address</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-address-agent.html"></div>
+
+</section>
+
+<section id="examples-for-address-agent">
+
+<h4>Examples for Address (Agent)</h4>
+
+<aside class="example" id="ex-address-agent" title="Address (Agent)">
+<p>The address in this example is the same of <a href="#ex-address-kind"></a>, but represented by using [[LOCN]].</p>
+<pre data-include-format="text" data-include="./examples/address-agent.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
+<!-- Address (Kind)-->
+
+<section id="properties-for-address-kind">
+
+<h3>+Address (Kind)</h3>
+
+<aside class="note">
+<p>This class is not included in [[DCAT-AP-20200608]].</p>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-address-kind.html"></div>
+
+<section id="recommended-properties-for-address-kind">
+
+<h4>Recommended properties for Address (Kind)</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#address-kind-administrative-area">administrative area</a></li>
+<li>+<a href="#address-kind-city">city</a></li>
+<li>+<a href="#address-kind-country">country</a></li>
+<li>+<a href="#address-kind-postal-code">postal code</a></li>
+<li>+<a href="#address-kind-street-address">street address</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-address-kind.html"></div>
+
+</section>
+
+<section id="examples-for-address-kind">
+
+<h4>Examples for Address (Kind)</h4>
+
+<aside class="example" id="ex-address-kind" title="Address (Kind)">
+<p>The address in this example is the same of <a href="#ex-address-agent"></a>, but represented by using [[VCARD-RDF]].</p>
+<pre data-include-format="text" data-include="./examples/address-kind.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
 <!-- Agent -->
 
 <section id="properties-for-agent">
@@ -407,6 +539,56 @@ A property which is not mentioned but would be applicable for a class according 
 
 <aside class="example" id="ex-agent" title="Agent">
 <pre data-include-format="text" data-include="./examples/agent.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
+<!-- Attribution -->
+
+<section id="properties-for-attribution">
+
+<h3>+Attribution</h3>
+
+<aside class="note">
+<p>This class is not included in [[DCAT-AP-20200608]].</p>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-attribution.html"></div>
+
+<p>The use of this class in GeoDCAT-AP is illustrated in <a class="no-sectionRef" href="#agent-roles"></a>.</p>
+
+<section id="mandatory-properties-for-attribution">
+
+<h4>Mandatory properties for Attribution</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#attribution-agent">agent</a></li>
+<li>+<a href="#attribution-had-role">had role</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-attribution.html"></div>
+
+</section>
+
+<section id="deprecated-properties-for-attribution">
+
+<h4>Deprecated properties for Attribution</h4>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/deprecated-properties-for-attribution.html"></div>
+
+</section>
+
+<section id="examples-for-attribution">
+
+<h4>Examples for Attribution</h4>
+
+<aside class="example" id="ex-attribution" title="Attribution">
+<pre data-include-format="text" data-include="./examples/attribution.ttl"></pre>
 </aside>
 
 </section>
@@ -854,6 +1036,46 @@ A property which is not mentioned but would be applicable for a class according 
 
 </section>
 
+<!-- Document -->
+
+<section id="properties-for-document">
+
+<h3>Document</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-document.html"></div>
+
+<section id="recommended-properties-for-document">
+
+<h4>Recommended properties for Document</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#document-description">description</a></li>
+<li>+<a href="#document-title">title</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-document.html"></div>
+
+</section>
+
+<section id="examples-for-document">
+
+<h4>Examples for Document</h4>
+
+<aside class="example" id="ex-document" title="Document">
+<pre data-include-format="text" data-include="./examples/document.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
 <!-- Identifier -->
 
 <section id="properties-for-identifier">
@@ -867,6 +1089,65 @@ A property which is not mentioned but would be applicable for a class according 
 <h4>Mandatory property for Identifier</h4>
 
 <div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-identifier.html"></div>
+
+</section>
+
+</section>
+
+<!-- Kind -->
+
+<section id="properties-for-kind">
+
+<h3>Kind</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-kind.html"></div>
+
+<section id="recommended-properties-for-kind">
+
+<h4>Recommended properties for Kind</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#kind-email">email</a></li>
+<li>+<a href="#kind-name">name</a></li>
+<li>+<a href="#kind-url">URL</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-kind.html"></div>
+
+</section>
+
+<section id="optional-properties-for-kind">
+
+<h4>Optional properties for Kind</h4>
+
+<aside class="note">
+<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#kind-address">address</a></li>
+<li>+<a href="#kind-affiliation">affiliation</a></li>
+<li>+<a href="#kind-name">name</a></li>
+<li>+<a href="#kind-phone">phone</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-kind.html"></div>
+
+</section>
+
+<section id="examples-for-kind">
+
+<h4>Examples for Kind</h4>
+
+<aside class="example" id="ex-kind" title="Kind">
+<pre data-include-format="text" data-include="./examples/kind.ttl"></pre>
+</aside>
 
 </section>
 
@@ -964,6 +1245,45 @@ A property which is not mentioned but would be applicable for a class according 
 
 </section>
 
+<!-- Media Type -->
+
+<section id="properties-for-media-type">
+
+<h3>Media Type</h3>
+
+<aside class="note">
+<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-media-type.html"></div>
+
+<section id="recommended-properties-for-media-type">
+
+<h4>Recommended property for Media Type</h4>
+
+<aside class="note">
+<p>The following property is not included in [[DCAT-AP-20200608]]:</p>
+<ul>
+<li>+<a href="#media-type-label">label</a></li>
+</ul>
+</aside>
+
+<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-media-type.html"></div>
+
+</section>
+
+<section id="examples-for-media-type">
+
+<h4>Examples for Media Type</h4>
+
+<aside class="example" id="ex-media-type" title="Media Type">
+<pre data-include-format="text" data-include="./examples/media-type.ttl"></pre>
+</aside>
+
+</section>
+
+</section>
+
 <!-- Period of Time -->
 
 <section id="properties-for-period-of-time">
@@ -1014,307 +1334,6 @@ A property which is not mentioned but would be applicable for a class according 
 
 </section>
 
-<!-- Relationship -->
-
-<section id="properties-for-relationship">
-
-<h3>Relationship</h3>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-relationship.html"></div>
-
-<section id="mandatory-properties-for-relationship">
-
-<h4>Mandatory properties for Relationship</h4>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-relationship.html"></div>
-
-</section>
-
-</section>
-
-<!-- Classes not in DCAT-AP -->
-
-<!-- Activity -->
-
-<section id="properties-for-activity">
-
-<h3>+Activity</h3>
-
-<aside class="note">
-<p>This class is not included in [[DCAT-AP-20200608]].</p>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-activity.html"></div>
-
-<p>The use of this class in GeoDCAT-AP is illustrated in <a class="no-sectionRef" href="#conformance-test-results"></a>.</p>
-
-<section id="mandatory-properties-for-activity">
-
-<h4>Mandatory properties for Activity</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#activity-generated">generated</a></li>
-<li>+<a href="#activity-qualified-association">qualified association</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-activity.html"></div>
-
-</section>
-
-<section id="examples-for-activity">
-
-<h4>Examples for Activity</h4>
-
-<p><a href="#ex-activity"></a> shows the use of class <code>prov:Activity</code> to specify the results of a testing activity assessing the conformance of a given resource against a given specification - as illustrated in <a class="no-sectionRef" href="#conformance-test-results"></a>.</p>
-
-<aside class="example" id="ex-activity" title="A testing activity">
-<pre data-include-format="text" data-include="./examples/activity.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Address (Agent)-->
-
-<section id="properties-for-address-agent">
-
-<h3>+Address (Agent)</h3>
-
-<aside class="note">
-<p>This class is not included in [[DCAT-AP-20200608]].</p>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-address-agent.html"></div>
-
-<section id="recommended-properties-for-address-agent">
-
-<h4>Recommended properties for Address (Agent)</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#address-agent-administrative-area">administrative area</a></li>
-<li>+<a href="#address-agent-city">city</a></li>
-<li>+<a href="#address-agent-country">country</a></li>
-<li>+<a href="#address-agent-postal-code">postal code</a></li>
-<li>+<a href="#address-agent-street-address">street address</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-address-agent.html"></div>
-
-</section>
-
-<section id="examples-for-address-agent">
-
-<h4>Examples for Address (Agent)</h4>
-
-<aside class="example" id="ex-address-agent" title="Address (Agent)">
-<p>The address in this example is the same of <a href="#ex-address-kind"></a>, but represented by using [[LOCN]].</p>
-<pre data-include-format="text" data-include="./examples/address-agent.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Address (Kind)-->
-
-<section id="properties-for-address-kind">
-
-<h3>+Address (Kind)</h3>
-
-<aside class="note">
-<p>This class is not included in [[DCAT-AP-20200608]].</p>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-address-kind.html"></div>
-
-<section id="recommended-properties-for-address-kind">
-
-<h4>Recommended properties for Address (Kind)</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#address-kind-administrative-area">administrative area</a></li>
-<li>+<a href="#address-kind-city">city</a></li>
-<li>+<a href="#address-kind-country">country</a></li>
-<li>+<a href="#address-kind-postal-code">postal code</a></li>
-<li>+<a href="#address-kind-street-address">street address</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-address-kind.html"></div>
-
-</section>
-
-<section id="examples-for-address-kind">
-
-<h4>Examples for Address (Kind)</h4>
-
-<aside class="example" id="ex-address-kind" title="Address (Kind)">
-<p>The address in this example is the same of <a href="#ex-address-agent"></a>, but represented by using [[VCARD-RDF]].</p>
-<pre data-include-format="text" data-include="./examples/address-kind.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Attribution -->
-
-<section id="properties-for-attribution">
-
-<h3>+Attribution</h3>
-
-<aside class="note">
-<p>This class is not included in [[DCAT-AP-20200608]].</p>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-attribution.html"></div>
-
-<p>The use of this class in GeoDCAT-AP is illustrated in <a class="no-sectionRef" href="#agent-roles"></a>.</p>
-
-<section id="mandatory-properties-for-attribution">
-
-<h4>Mandatory properties for Attribution</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#attribution-agent">agent</a></li>
-<li>+<a href="#attribution-had-role">had role</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-attribution.html"></div>
-
-</section>
-
-<section id="deprecated-properties-for-attribution">
-
-<h4>Deprecated properties for Attribution</h4>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/deprecated-properties-for-attribution.html"></div>
-
-</section>
-
-<section id="examples-for-attribution">
-
-<h4>Examples for Attribution</h4>
-
-<aside class="example" id="ex-attribution" title="Attribution">
-<pre data-include-format="text" data-include="./examples/attribution.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Document -->
-
-<section id="properties-for-document">
-
-<h3>Document</h3>
-
-<aside class="note">
-<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-document.html"></div>
-
-<section id="recommended-properties-for-document">
-
-<h4>Recommended properties for Document</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#document-description">description</a></li>
-<li>+<a href="#document-title">title</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-document.html"></div>
-
-</section>
-
-<section id="examples-for-document">
-
-<h4>Examples for Document</h4>
-
-<aside class="example" id="ex-document" title="Document">
-<pre data-include-format="text" data-include="./examples/document.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
-<!-- Kind -->
-
-<section id="properties-for-kind">
-
-<h3>Kind</h3>
-
-<aside class="note">
-<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-kind.html"></div>
-
-<section id="recommended-properties-for-kind">
-
-<h4>Recommended properties for Kind</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#kind-email">email</a></li>
-<li>+<a href="#kind-name">name</a></li>
-<li>+<a href="#kind-url">URL</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-kind.html"></div>
-
-</section>
-
-<section id="optional-properties-for-kind">
-
-<h4>Optional properties for Kind</h4>
-
-<aside class="note">
-<p>The following properties are not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#kind-address">address</a></li>
-<li>+<a href="#kind-affiliation">affiliation</a></li>
-<li>+<a href="#kind-name">name</a></li>
-<li>+<a href="#kind-phone">phone</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/optional-properties-for-kind.html"></div>
-
-</section>
-
-<section id="examples-for-kind">
-
-<h4>Examples for Kind</h4>
-
-<aside class="example" id="ex-kind" title="Kind">
-<pre data-include-format="text" data-include="./examples/kind.ttl"></pre>
-</aside>
-
-</section>
-
-</section>
-
 <!-- Provenance Statement -->
 
 <section id="properties-for-provenance-statement">
@@ -1354,44 +1373,25 @@ A property which is not mentioned but would be applicable for a class according 
 
 </section>
 
-<!-- Media Type -->
+<!-- Relationship -->
 
-<section id="properties-for-media-type">
+<section id="properties-for-relationship">
 
-<h3>Media Type</h3>
+<h3>Relationship</h3>
 
-<aside class="note">
-<p>This class is not explicitly associated with any property in [[DCAT-AP-20200608]].</p>
-</aside>
+<div data-include-format="html" data-include-replace="true" data-include="./tables/class-relationship.html"></div>
 
-<div data-include-format="html" data-include-replace="true" data-include="./tables/class-media-type.html"></div>
+<section id="mandatory-properties-for-relationship">
 
-<section id="recommended-properties-for-media-type">
+<h4>Mandatory properties for Relationship</h4>
 
-<h4>Recommended property for Media Type</h4>
-
-<aside class="note">
-<p>The following property is not included in [[DCAT-AP-20200608]]:</p>
-<ul>
-<li>+<a href="#media-type-label">label</a></li>
-</ul>
-</aside>
-
-<div data-include-format="html" data-include-replace="true" data-include="./tables/recommended-properties-for-media-type.html"></div>
-
-</section>
-
-<section id="examples-for-media-type">
-
-<h4>Examples for Media Type</h4>
-
-<aside class="example" id="ex-media-type" title="Media Type">
-<pre data-include-format="text" data-include="./examples/media-type.ttl"></pre>
-</aside>
+<div data-include-format="html" data-include-replace="true" data-include="./tables/mandatory-properties-for-relationship.html"></div>
 
 </section>
 
 </section>
+
+<!-- Classes not in DCAT-AP -->
 
 <!-- Rights Statement -->
 


### PR DESCRIPTION
See [EDNOTE in §4](https://semiceu.github.io/GeoDCAT-AP/drafts/2.0.0-draft-0.1/#properties).

Sort sections alphabetically.

Additional revisions:
- Add NOTEs for classes that in DCAT-AP are not explicitly associated with any property

Preview: https://raw.githack.com/SEMICeu/GeoDCAT-AP/fix-subsection-order-sec4-1/drafts/latest/index.html